### PR TITLE
fix: correct-prompt-text-of-reminder-pop-up-2

### DIFF
--- a/src/PicTimeTagManage/Form1.menuHandle.cs
+++ b/src/PicTimeTagManage/Form1.menuHandle.cs
@@ -142,7 +142,7 @@ namespace PicTimeTagManage
             }
             if (selectedRows.Count >= 20)
             {
-                string Mesg = $"你选择了{selectedRows.Count}个文件，读取文件exif信息将非常耗时，界面会假死，请耐心等待！如果你不想继续操作，请点击取消按钮。";
+                string Mesg = $"你选择了{selectedRows.Count}个文件，读取文件exif信息将非常耗时，界面会假死，请耐心等待！如果你不想继续操作，请点击按钮“否”。";
                 DialogResult dialogResult = MessageBox.Show(Mesg, "重要提醒", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
                 if (dialogResult == DialogResult.Yes)
                 {


### PR DESCRIPTION
修复了提醒弹窗的提示文字错别字
<img width="476" height="169" alt="image" src="https://github.com/user-attachments/assets/a6794f8d-c0e1-4371-8a11-3d935aedb9fb" />

修复 #2 